### PR TITLE
Fixed http_build_query() deprecation in PHP 8.1

### DIFF
--- a/src/AdobeConnect/Request.php
+++ b/src/AdobeConnect/Request.php
@@ -26,7 +26,7 @@ class Request
         $this->params = array_map(function ($param) {
             return urlencode($param);
         }, $params);
-        $this->uri = sprintf('?%s', http_build_query(array_merge(array('action' => $action), $params), null, '&'));
+        $this->uri = sprintf('?%s', http_build_query(array_merge(array('action' => $action), $params), '', '&'));
         $host = stripos($host, 'http') !== false ? $host : 'https://' . $host;
         $this->url = sprintf('%s/api/xml%s', $host, $this->uri);
     }
@@ -60,4 +60,4 @@ class Request
     {
         return $this->url;
     }
-} 
+}


### PR DESCRIPTION
Passing `null` to non-nullable internal function parameters was deprecated in PHP 8.1:
https://www.php.net/releases/8.1/en.php#deprecations_and_bc_breaks

Setting the argument to the default `''` fixes this while keeping compatibility with older PHP versions.